### PR TITLE
Rename JADE_DIR to __JADE_DIR__ and add a docstring

### DIFF
--- a/src/JADE.jl
+++ b/src/JADE.jl
@@ -12,11 +12,16 @@ using JuMP, SDDP, Random, DelimitedFiles, JSON
 const SECONDSPERHOUR = 3600
 const WEEKSPERYEAR = 52
 
-macro JADE_DIR()
-    ex = quote
-        get(ENV, "JADE_DIR", "")::String
-    end
-    return esc(ex)
+"""
+    @__JADE_DIR__
+
+Get the current location of the `ENV["JADE_DIR"]` variable set by the user.
+
+This could have been a function, but we use a macro with double underscores to
+match `@__DIR__` and `@__FILE__`.
+"""
+macro __JADE_DIR__()
+    return esc(:(get(ENV, "JADE_DIR", "")::String))
 end
 
 JSON.lower(t::SDDP.Expectation) = (1.0, 1.0)

--- a/src/data.jl
+++ b/src/data.jl
@@ -635,8 +635,13 @@ function backup_input_files(rundata::RunData)
         "thermal_fuel_supply.csv",
     ]
 
-    out_path =
-        joinpath(@JADE_DIR, "Output", rundata.data_dir, rundata.policy_dir, "data_files")
+    out_path = joinpath(
+        @__JADE_DIR__,
+        "Output",
+        rundata.data_dir,
+        rundata.policy_dir,
+        "data_files",
+    )
 
     if !isdir(out_path)
         mkdir(out_path)

--- a/src/data/hydro.jl
+++ b/src/data/hydro.jl
@@ -383,7 +383,7 @@ function diatofile(
     outpath::String,
     policy_dir::String,
 )
-    outpath = joinpath(@JADE_DIR, "Output", outpath)
+    outpath = joinpath(@__JADE_DIR__, "Output", outpath)
     if !ispath(joinpath(outpath, policy_dir))
         mkpath(joinpath(outpath, policy_dir))
     end

--- a/src/results.jl
+++ b/src/results.jl
@@ -35,7 +35,7 @@ function write_sim_results(
     s = d.sets
 
     data_dir = joinpath(
-        @JADE_DIR,
+        @__JADE_DIR__,
         "Output",
         d.rundata.data_dir,
         d.rundata.policy_dir,
@@ -287,7 +287,7 @@ function write_training_results(
     d::JADEData,
     solveoptions::JADESolveOptions,
 )
-    data_dir = joinpath(@JADE_DIR, "Output", d.rundata.data_dir)
+    data_dir = joinpath(@__JADE_DIR__, "Output", d.rundata.data_dir)
 
     !ispath(data_dir) && mkpath(data_dir)
 
@@ -318,14 +318,14 @@ function write_training_results(
         if d.rundata.number_of_wks == 52 && d.rundata.steady_state == true
             @info("Creating EOH cuts in " * joinpath("Input", "d.rundata.data_dir", "EOH"))
 
-            if !ispath(joinpath(@JADE_DIR, "Input", d.rundata.data_dir, "EOH"))
-                mkpath(joinpath(@JADE_DIR, "Input", d.rundata.data_dir, "EOH"))
+            if !ispath(joinpath(@__JADE_DIR__, "Input", d.rundata.data_dir, "EOH"))
+                mkpath(joinpath(@__JADE_DIR__, "Input", d.rundata.data_dir, "EOH"))
             end
 
             JADE.write_cuts_to_file(
                 sddpm,
                 joinpath(
-                    @JADE_DIR,
+                    @__JADE_DIR__,
                     "Input",
                     d.rundata.data_dir,
                     "EOH",
@@ -336,7 +336,7 @@ function write_training_results(
 
             open(
                 joinpath(
-                    @JADE_DIR,
+                    @__JADE_DIR__,
                     "Input",
                     d.rundata.data_dir,
                     "EOH",
@@ -348,7 +348,7 @@ function write_training_results(
             end
             open(
                 joinpath(
-                    @JADE_DIR,
+                    @__JADE_DIR__,
                     "Input",
                     d.rundata.data_dir,
                     "EOH",
@@ -378,7 +378,7 @@ function output_tidy_results(
     variables::Array{Symbol,1},
 )
     data_dir = joinpath(
-        @JADE_DIR,
+        @__JADE_DIR__,
         "Output",
         d.rundata.data_dir,
         d.rundata.policy_dir,

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -36,8 +36,13 @@ function simulate(JADEmodel::JADEModel, parameters::JADESimulation)
         joinpath("Input", d.rundata.data_dir)
     )
 
-    cuts_path =
-        joinpath(@JADE_DIR, "Output", d.rundata.data_dir, d.rundata.policy_dir, "cuts.json")
+    cuts_path = joinpath(
+        @__JADE_DIR__,
+        "Output",
+        d.rundata.data_dir,
+        d.rundata.policy_dir,
+        "cuts.json",
+    )
 
     if length(sddpm.nodes[1].bellman_function.global_theta.cuts) == 0
         if isfile(cuts_path)

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -44,13 +44,13 @@ function optimize_policy!(
     check_settings_compatibility(rundata = d.rundata, solveoptions = solveoptions)
 
     if solveoptions.savedcuts != ""
-        cuts_path = joinpath(@JADE_DIR, "Output", solveoptions.savedcuts, "cuts.json")
+        cuts_path = joinpath(@__JADE_DIR__, "Output", solveoptions.savedcuts, "cuts.json")
         if isfile(cuts_path) && solveoptions.warmstart_cuts
             previous_rundata = load_model_parameters(solveoptions.savedcuts)
         end
     else
         cuts_path = joinpath(
-            @JADE_DIR,
+            @__JADE_DIR__,
             "Output",
             d.rundata.data_dir,
             d.rundata.policy_dir,
@@ -73,7 +73,7 @@ function optimize_policy!(
         final_week = mod(d.rundata.start_wk + d.rundata.number_of_wks - 2, 52) + 1
 
         cuts_path = joinpath(
-            @JADE_DIR,
+            @__JADE_DIR__,
             "Input",
             d.rundata.data_dir,
             "EOH",
@@ -88,7 +88,7 @@ function optimize_policy!(
 
         previous_rundata = load_model_parameters(
             joinpath(
-                @JADE_DIR,
+                @__JADE_DIR__,
                 "Input",
                 d.rundata.data_dir,
                 "EOH",
@@ -123,7 +123,7 @@ function optimize_policy!(
                 @info("Existing cuts detected in model; these cuts will be retained")
             end
             cuts_path = joinpath(
-                @JADE_DIR,
+                @__JADE_DIR__,
                 "Output",
                 d.rundata.data_dir,
                 d.rundata.policy_dir,
@@ -158,7 +158,7 @@ function optimize_policy!(
         if solveoptions.fractionMC != 1.0
             sequences = Vector{Vector{Int}}
             seq_path = joinpath(
-                @JADE_DIR,
+                @__JADE_DIR__,
                 "Input",
                 d.rundata.data_dir,
                 solveoptions.custom_inflow_file,

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -34,7 +34,7 @@ data files.
 `run_file` is the name of the csv file that contains the parameters we wish to load.
 """
 function define_JADE_model(inputdir::String; run_file::String = "run")
-    file = joinpath(@JADE_DIR, "Input", inputdir, run_file * ".csv")
+    file = joinpath(@__JADE_DIR__, "Input", inputdir, run_file * ".csv")
     run_options = parse_run_options(file)
 
     # Scaling factor for reservoir volume
@@ -264,7 +264,7 @@ is located.
 `run_file` is the name of the csv file containing the parameters for the simulation.
 """
 function define_JADE_simulation(inputdir::String; run_file = "run")
-    file = joinpath(@JADE_DIR, "Input", inputdir, run_file * ".csv")
+    file = joinpath(@__JADE_DIR__, "Input", inputdir, run_file * ".csv")
     run_options = parse_run_options(file)
 
     reset_starting_levels = :default
@@ -537,7 +537,7 @@ is located.
 `run_file` is the name of the csv file containing the parameters for the simulation.
 """
 function define_JADE_solve_options(inputdir::String; run_file = "run")
-    file = joinpath(@JADE_DIR, "Input", inputdir, run_file * ".csv")
+    file = joinpath(@__JADE_DIR__, "Input", inputdir, run_file * ".csv")
     run_options = parse_run_options(file)
 
     riskmeasure = (0.0, 1.0)
@@ -765,7 +765,7 @@ end
 
 function load_model_parameters(path::String)
     if ':' ∉ path
-        path = joinpath(@JADE_DIR, "Output", path, "rundata.json")
+        path = joinpath(@__JADE_DIR__, "Output", path, "rundata.json")
     end
 
     if !ispath(path)
@@ -820,7 +820,7 @@ function load_model_parameters(path::String)
 end
 
 function load_solve_parameters(model::String, policy::String)
-    path = joinpath(@JADE_DIR, "Output", model, policy, "solveoptions.json")
+    path = joinpath(@__JADE_DIR__, "Output", model, policy, "solveoptions.json")
 
     if !ispath(path)
         error("Solve options not found in Output" * joinpath("Output", model, policy))
@@ -855,7 +855,8 @@ function load_solve_parameters(model::String, policy::String)
 end
 
 function load_simulation_parameters(model::String, policy::String, simulation::String)
-    path = joinpath(@JADE_DIR, "Output", model, policy, simulation, "sim_parameters.json")
+    path =
+        joinpath(@__JADE_DIR__, "Output", model, policy, simulation, "sim_parameters.json")
     if !ispath(path)# || !ispath(joinpath(data_dir,rundata.json))
         error("Parameters for simulation not found")
     end
@@ -1192,7 +1193,7 @@ a `scenario_dir` then the first directory to search is <data_dir>/data_files/<sc
 `verbose` if set to `true` the function will print info to the REPL.
 """
 function get_file_directory(x::String, rundata::RunData; verbose::Bool = true)
-    input_directory = joinpath(@JADE_DIR, "Input", rundata.data_dir)
+    input_directory = joinpath(@__JADE_DIR__, "Input", rundata.data_dir)
 
     if rundata.scenario_dir != "" &&
        !isdir(joinpath(input_directory, "data_files", rundata.scenario_dir))

--- a/test/data_validation.jl
+++ b/test/data_validation.jl
@@ -29,7 +29,7 @@ function runtests()
 end
 
 function _input_file(s)
-    return joinpath(JADE.@JADE_DIR, "Input", "test1", s)
+    return joinpath(JADE.@__JADE_DIR__, "Input", "test1", s)
 end
 
 function test_data_thermal_stations()


### PR DESCRIPTION
This one is up for debate.

This could/should be a function:
```julia
JADE_DIR() = get(ENV, "JADE_DIR", "")::String
```
with usage `joinpath(JADE_DIR(), "foo")`.

I try to avoid macros where possible, because they just add complexity and are hard for new-to-Julia developers to understand. This one isn't complicated though, so perhaps it's okay. I've renamed to `@__JADE_DIR__` to match the other `@__XXX__` macros like `DIR`, `MODULE`, and `FILE`, but I'm okay to close this without merging if it's just change for change's sake.

Closes #9