### PR TITLE
Switch packages to import to force namespacing their methods

### DIFF
--- a/src/JADE.jl
+++ b/src/JADE.jl
@@ -7,7 +7,12 @@
 
 module JADE
 
-using JuMP, SDDP, Random, DelimitedFiles, JSON
+import DelimitedFiles
+import JSON
+import JuMP
+import Random
+import Statistics
+import SDDP
 
 const SECONDSPERHOUR = 3600
 const WEEKSPERYEAR = 52

--- a/src/data.jl
+++ b/src/data.jl
@@ -5,8 +5,6 @@
 #  If a copy of the MPL was not distributed with this file, You can obtain one at
 #  http://mozilla.org/MPL/2.0/.
 
-import Statistics: mean, max
-
 """
 	parsefile(f::Function, file::String, trim::Bool = false)
 

--- a/src/data/hydro.jl
+++ b/src/data/hydro.jl
@@ -333,7 +333,8 @@ function adjustinflows(inflow_file::String, rundata::RunData)
         N = length(years)
         # Follow the steps in DOASA paper
         α = [  # mean historical inflow
-            mean(inflow for (tp, inflow) in zip(tps, infl) if tp.week == t) for t in weeks
+            Statistics.mean(inflow for (tp, inflow) in zip(tps, infl) if tp.week == t)
+            for t in weeks
         ]
         W = [] # rolling total inflow starting from week ty
         for ty in 1:length(infl)
@@ -345,13 +346,15 @@ function adjustinflows(inflow_file::String, rundata::RunData)
             end
         end
         m = [  # mean of the rolling inflow
-            mean(W[i] for (i, tp) in enumerate(tps) if tp.week == t) for t in weeks
+            Statistics.mean(W[i] for (i, tp) in enumerate(tps) if tp.week == t) for
+            t in weeks
         ]
         d = [  # mean + the bigger deviation
             max(0.0, α[tp.week] + (W[i] - m[tp.week]) / √ω) for (i, tp) in enumerate(tps)
         ]
         d_mean = [  # mean of adjusted values
-            mean(d[i] for (i, tp) in enumerate(tps) if tp.week == t) for t in weeks
+            Statistics.mean(d[i] for (i, tp) in enumerate(tps) if tp.week == t) for
+            t in weeks
         ]
         k = [  # adjusted inflows
             isnan(d[i] * α[tp.week] / d_mean[tp.week]) ? α[tp.week] :

--- a/src/model.jl
+++ b/src/model.jl
@@ -84,7 +84,7 @@ function JADEsddp(d::JADEData, optimizer = nothing)
         #------------------------------------------------------------------------
         # State variable: water in reservoirs
         #------------------------------------------------------------------------
-        @variable(
+        JuMP.@variable(
             md,
             -sum(
                 d.reservoirs[r].contingent[timenow][j].level / scale_factor for
@@ -103,7 +103,7 @@ function JADEsddp(d::JADEData, optimizer = nothing)
         FLOWUNDER = [a for a in s.NATURAL_ARCS if d.natural_arcs[a].minflow != 0.0]
         SPILLOVER = [a for a in s.STATION_ARCS if d.station_arcs[a].maxflow != Inf]
 
-        @variables(
+        JuMP.@variables(
             md,
             begin
                 # Dispatch of energy in MW from hydro stations
@@ -153,7 +153,7 @@ function JADEsddp(d::JADEData, optimizer = nothing)
         )
 
         if d.rundata.losses != :none
-            @variables(
+            JuMP.@variables(
                 md,
                 begin
                     # Positive partof transflow
@@ -182,7 +182,7 @@ function JADEsddp(d::JADEData, optimizer = nothing)
         # Define handy expressions
         #------------------------------------------------------------------------
 
-        @expressions(
+        JuMP.@expressions(
             md,
             begin
                 # Number of hours in a week
@@ -239,7 +239,7 @@ function JADEsddp(d::JADEData, optimizer = nothing)
 
         # Total supply of electricity at any node and block
         if d.rundata.losses != :none
-            @expression(
+            JuMP.@expression(
                 md,
                 supply[n in s.NODES, bl in s.BLOCKS],
                 d.durations[timenow][bl] * (
@@ -249,7 +249,7 @@ function JADEsddp(d::JADEData, optimizer = nothing)
                 )
             )
         else
-            @expression(
+            JuMP.@expression(
                 md,
                 supply[n in s.NODES, bl in s.BLOCKS],
                 d.durations[timenow][bl] * (
@@ -263,7 +263,7 @@ function JADEsddp(d::JADEData, optimizer = nothing)
         #------------------------------------------------------------------------
         # Define constraints
         #------------------------------------------------------------------------
-        @constraints(
+        JuMP.@constraints(
             md,
             begin
                 # Lower and upper bounds on flows
@@ -343,7 +343,7 @@ function JADEsddp(d::JADEData, optimizer = nothing)
         )
 
         if length(CONTINGENT) != 0
-            @constraints(
+            JuMP.@constraints(
                 md,
                 begin
                     contingentstorage[r in CONTINGENT],
@@ -365,7 +365,7 @@ function JADEsddp(d::JADEData, optimizer = nothing)
         ###################
         #ABP losses code
         if d.rundata.losses != :none
-            @constraints(
+            JuMP.@constraints(
                 md,
                 begin
                     # Define flow tranches for piecewise linear losses.
@@ -417,7 +417,7 @@ function JADEsddp(d::JADEData, optimizer = nothing)
             )
 
             # Half line losses are to be added to load at each end of the line
-            @constraints(
+            JuMP.@constraints(
                 md,
                 begin
                     defineNodalLosses[n in s.NODES, bl in s.BLOCKS],
@@ -441,9 +441,9 @@ function JADEsddp(d::JADEData, optimizer = nothing)
         # Flow-conservation-related calculations
         #------------------------------------------------------------------------
         # Get an inflow for every location with inflow data
-        # @variable(md, ω[s.CATCHMENTS_WITH_INFLOW])
+        # JuMP.@variable(md, ω[s.CATCHMENTS_WITH_INFLOW])
         # for c in s.CATCHMENTS_WITH_INFLOW
-        #     @constraint(md, inflow[c] == ω[c])
+        #     JuMP.@constraint(md, inflow[c] == ω[c])
         # end
 
         inflow_uncertainty = Array{Dict{Symbol,Float64},1}()
@@ -465,7 +465,7 @@ function JADEsddp(d::JADEData, optimizer = nothing)
             end
         end
 
-        @constraints(
+        JuMP.@constraints(
             md,
             begin
                 # Conservation for reservoirs
@@ -521,11 +521,11 @@ function JADEsddp(d::JADEData, optimizer = nothing)
                 )
 
             if dr.boundtype == :upper
-                @constraint(md, LHS <= RHS)
+                JuMP.@constraint(md, LHS <= RHS)
             elseif dr.boundtype == :lower
-                @constraint(md, LHS >= RHS)
+                JuMP.@constraint(md, LHS >= RHS)
             elseif dr.boundtype == :equality
-                @constraint(md, LHS == RHS)
+                JuMP.@constraint(md, LHS == RHS)
             else
                 error("Invalid bound type: " * string(dr.boundtype))
             end
@@ -534,7 +534,7 @@ function JADEsddp(d::JADEData, optimizer = nothing)
         #------------------------------------------------------------------------
         # Objective-related calculations
         #------------------------------------------------------------------------
-        @expression(
+        JuMP.@expression(
             md,
             lostloadcosts,
             sum(
@@ -553,7 +553,7 @@ function JADEsddp(d::JADEData, optimizer = nothing)
             )
         )
 
-        @expression(
+        JuMP.@expression(
             md,
             contingent_storage_cost,
             sum(
@@ -563,7 +563,7 @@ function JADEsddp(d::JADEData, optimizer = nothing)
             )
         )
 
-        @expression(
+        JuMP.@expression(
             md,
             carbon_emissions[t in s.THERMALS, bl in s.BLOCKS],
             d.carbon_content[d.thermal_stations[t].fuel] *
@@ -572,7 +572,7 @@ function JADEsddp(d::JADEData, optimizer = nothing)
             d.durations[timenow][bl]
         )
 
-        @expression(
+        JuMP.@expression(
             md,
             immediate_cost,
             sum(
@@ -593,10 +593,10 @@ function JADEsddp(d::JADEData, optimizer = nothing)
 
         if stage < number_of_wks || !d.rundata.use_terminal_mwvs
             # Stage cost function not including terminal water value
-            @stageobjective(md, immediate_cost / scale_obj)
+            SDDP.@stageobjective(md, immediate_cost / scale_obj)
         else
             # Convert stored water in Mm³ to MWh
-            @expression(
+            JuMP.@expression(
                 md,
                 storedenergy,
                 1E6 *
@@ -605,14 +605,14 @@ function JADEsddp(d::JADEData, optimizer = nothing)
             )
 
             for cut in d.terminal_eqns # -terminalcost for value
-                @constraint(
+                JuMP.@constraint(
                     md,
                     (-terminalcost) <=
                     (cut.intercept + cut.coefficient * storedenergy) / scale_obj
                 )
             end
             # Cost function includes terminal values added
-            @stageobjective(md, immediate_cost / scale_obj + terminalcost)
+            SDDP.@stageobjective(md, immediate_cost / scale_obj + terminalcost)
         end
     end
 

--- a/src/results.jl
+++ b/src/results.jl
@@ -92,7 +92,7 @@ function write_sim_results(
     #------------------------------------
     # Final objective
     #------------------------------------
-    writedlm(
+    DelimitedFiles.writedlm(
         outdir("TotalCost.csv"),
         [results[i][end][:running_cost] for i in 1:nsims],
         ',',

--- a/src/sddp_modifications.jl
+++ b/src/sddp_modifications.jl
@@ -37,8 +37,8 @@ function read_finalcuts_from_file(
     node_name = node_name_parser(T, string(laststage))::T
     node = model[node_name]
     bf = node.bellman_function
-    if has_upper_bound(bf.global_theta.theta)
-        delete_upper_bound(bf.global_theta.theta)
+    if JuMP.has_upper_bound(bf.global_theta.theta)
+        JuMP.delete_upper_bound(bf.global_theta.theta)
     end
     cuts = JSON.parsefile(filename, use_mmap = false)
     for node_cuts in cuts
@@ -95,15 +95,15 @@ function read_finalcuts_from_file(
         # Here is part (ii): adding the constraints that define the risk-set
         # representation of the risk measure.
         for json_cut in node_cuts["risk_set_cuts"]
-            expr = @expression(
+            expr = JuMP.@expression(
                 node.subproblem,
                 bf.global_theta.theta -
                 sum(p * V.theta for (p, V) in zip(json_cut, bf.local_thetas))
             )
             if JuMP.objective_sense(node.subproblem) == MOI.MIN_SENSE
-                @constraint(node.subproblem, expr >= 0)
+                JuMP.@constraint(node.subproblem, expr >= 0)
             else
-                @constraint(node.subproblem, expr <= 0)
+                JuMP.@constraint(node.subproblem, expr <= 0)
             end
         end
     end

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -5,8 +5,6 @@
 #  If a copy of the MPL was not distributed with this file, You can obtain one at
 #  http://mozilla.org/MPL/2.0/.
 
-using Random
-
 """
 	simulate(JADEmodel::JADEModel, parameters::JADESimulation)
 
@@ -49,10 +47,10 @@ function simulate(JADEmodel::JADEModel, parameters::JADESimulation)
                 load_model_parameters(d.rundata.data_dir, d.rundata.policy_dir)
             check_rundata(d.rundata, previous_rundata, :partial)
             SDDP.read_cuts_from_file(sddpm, cuts_path)
-            if has_upper_bound(
+            if JuMP.has_upper_bound(
                 sddpm.nodes[d.rundata.number_of_wks].bellman_function.global_theta.theta,
             )
-                delete_upper_bound(
+                JuMP.delete_upper_bound(
                     sddpm.nodes[d.rundata.number_of_wks].bellman_function.global_theta.theta,
                 )
             end

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -106,10 +106,10 @@ function optimize_policy!(
                 @info("Loading cuts from " * cuts_path)
                 check_rundata(d.rundata, previous_rundata, :full)
                 SDDP.read_cuts_from_file(sddpm, cuts_path)
-                if has_upper_bound(
+                if JuMP.has_upper_bound(
                     sddpm.nodes[d.rundata.number_of_wks].bellman_function.global_theta.theta,
                 )
-                    delete_upper_bound(
+                    JuMP.delete_upper_bound(
                         sddpm.nodes[d.rundata.number_of_wks].bellman_function.global_theta.theta,
                     )
                 end

--- a/src/visualise.jl
+++ b/src/visualise.jl
@@ -5,12 +5,10 @@
 #  If a copy of the MPL was not distributed with this file, You can obtain one at
 #  http://mozilla.org/MPL/2.0/.
 
-using Random
-
 """
     plot_storage(
         results::Array{Array{Dict{Symbol,Any},1},1},
-        filename::String = randstring(6);
+        filename::String = Random.randstring(6);
         reservoirs::Array{Symbol,1} = collect(keys(results[1][1][:reslevel])),
     )
 
@@ -27,7 +25,7 @@ storage (GWh) as an interactive webpage.
 """
 function plot_storage(
     results::Array{Array{Dict{Symbol,Any},1},1},
-    filename::String = randstring(6);
+    filename::String = Random.randstring(6);
     reservoirs::Any = collect(keys(results[1][1][:reslevel])),
     fuels::Any = collect(keys(results[1][1][:fuel_storage])),
 )
@@ -65,7 +63,7 @@ end
 """
     plot_prices(
         results::Array{Array{Dict{Symbol,Any},1},1},
-        filename::String = randstring(6);
+        filename::String = Random.randstring(6);
         nodes::Array{Symbol,1} = results[1][1][:prices].axes[1],
         blocks::Array{Symbol,1} = results[1][1][:prices].axes[2],
     )
@@ -85,7 +83,7 @@ total storage (GWh) as an interactive webpage.
 """
 function plot_prices(
     results::Array{Array{Dict{Symbol,Any},1},1},
-    filename::String = randstring(6);
+    filename::String = Random.randstring(6);
     nodes::Array{Symbol,1} = results[1][1][:prices].axes[1],
     blocks::Array{Symbol,1} = results[1][1][:prices].axes[2],
 )
@@ -109,7 +107,7 @@ end
 """
     plot_watervalues(
         results::Array{Array{Dict{Symbol,Any},1},1},
-        filename::String = randstring(6);
+        filename::String = Random.randstring(6);
         reservoirs::Array{Symbol,1} = collect(keys(results[1][1][:reslevel])),
     )
 
@@ -126,7 +124,7 @@ storage (GWh) as an interactive webpage.
 """
 function plot_watervalues(
     results::Array{Array{Dict{Symbol,Any},1},1},
-    filename::String = randstring(6);
+    filename::String = Random.randstring(6);
     reservoirs::Any = collect(keys(results[1][1][:reslevel])),
     fuels::Any = collect(keys(results[1][1][:fuel_storage])),
 )


### PR DESCRIPTION
This is good developement practice because it makes it easier to find which packages are used where in the codebase.

It means that we can see `DelimitedFiles` is used only for a single `writedlm` call.