### PR TITLE
Add SDDP.Threaded() to the train and simulate stages 

### DIFF
--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -20,8 +20,12 @@ all the corresponding data.
 
 `parameters` contains all the simulation information, including the number of
 replications, the type of simulation, the hydrological years to sample from, etc.
+
+### Keyword Arguments
+`async` is a boolean that sets whether SDDP.jl will run in parallel. Currently
+recommended to be set to false.
 """
-function simulate(JADEmodel::JADEModel, parameters::JADESimulation)
+function simulate(JADEmodel::JADEModel, parameters::JADESimulation; async::Bool=false)
     d = JADEmodel.d
     sddpm = JADEmodel.sddpm
 
@@ -160,6 +164,7 @@ function simulate(JADEmodel::JADEModel, parameters::JADESimulation)
                     terminate_on_cycle = false,
                     terminate_on_dummy_leaf = false,
                 ),
+                parallel_scheme = async ? SDDP.Threaded() : SDDP.Serial(),
                 incoming_state = initial_state,
             )
 
@@ -196,6 +201,7 @@ function simulate(JADEmodel::JADEModel, parameters::JADESimulation)
                     terminate_on_cycle = false,
                     terminate_on_dummy_leaf = false,
                 ),
+                parallel_scheme = async ? SDDP.Threaded() : SDDP.Serial(),
                 incoming_state = initial_state,
             )
 
@@ -284,6 +290,7 @@ function simulate(JADEmodel::JADEModel, parameters::JADESimulation)
                 get_primal,
                 sampling_scheme = SDDP.Historical(sample_paths),
                 custom_recorders = get_dual,
+                parallel_scheme = async ? SDDP.Threaded() : SDDP.Serial(),
                 incoming_state = initial_state,
             )
 
@@ -331,6 +338,7 @@ function simulate(JADEmodel::JADEModel, parameters::JADESimulation)
                 get_primal,
                 sampling_scheme = SDDP.Historical(sample_path),
                 custom_recorders = get_dual,
+                parallel_scheme = async ? SDDP.Threaded() : SDDP.Serial(),
                 incoming_state = initial_state,
             )
         end

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -25,9 +25,10 @@ replications, the type of simulation, the hydrological years to sample from, etc
 `async` is a boolean that sets whether SDDP.jl will run in parallel. Currently
 recommended to be set to false.
 """
-function simulate(JADEmodel::JADEModel, parameters::JADESimulation; async::Bool=false)
+function simulate(JADEmodel::JADEModel, parameters::JADESimulation; multithreaded::Bool=false)
     d = JADEmodel.d
     sddpm = JADEmodel.sddpm
+    parallel_scheme = multithreaded ? SDDP.Threaded() : SDDP.Serial()
 
     check_settings_compatibility(rundata = d.rundata, simulation = parameters)
 
@@ -164,7 +165,7 @@ function simulate(JADEmodel::JADEModel, parameters::JADESimulation; async::Bool=
                     terminate_on_cycle = false,
                     terminate_on_dummy_leaf = false,
                 ),
-                parallel_scheme = async ? SDDP.Threaded() : SDDP.Serial(),
+                parallel_scheme = parallel_scheme,
                 incoming_state = initial_state,
             )
 
@@ -201,7 +202,7 @@ function simulate(JADEmodel::JADEModel, parameters::JADESimulation; async::Bool=
                     terminate_on_cycle = false,
                     terminate_on_dummy_leaf = false,
                 ),
-                parallel_scheme = async ? SDDP.Threaded() : SDDP.Serial(),
+                parallel_scheme = parallel_scheme,
                 incoming_state = initial_state,
             )
 
@@ -290,7 +291,7 @@ function simulate(JADEmodel::JADEModel, parameters::JADESimulation; async::Bool=
                 get_primal,
                 sampling_scheme = SDDP.Historical(sample_paths),
                 custom_recorders = get_dual,
-                parallel_scheme = async ? SDDP.Threaded() : SDDP.Serial(),
+                parallel_scheme = parallel_scheme,
                 incoming_state = initial_state,
             )
 
@@ -338,7 +339,7 @@ function simulate(JADEmodel::JADEModel, parameters::JADESimulation; async::Bool=
                 get_primal,
                 sampling_scheme = SDDP.Historical(sample_path),
                 custom_recorders = get_dual,
-                parallel_scheme = async ? SDDP.Threaded() : SDDP.Serial(),
+                parallel_scheme = parallel_scheme,
                 incoming_state = initial_state,
             )
         end

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -249,8 +249,8 @@ function optimize_policy!(
 
         parallel_scheme = nothing
         if async
-            if d.parallel_optimizer == nothing
-                parallel_scheme = SDDP.Asynchronous()
+            if !hasproperty(d, :parallel_scheme)
+                parallel_scheme = SDDP.Threaded()
             else
                 parallel_scheme = SDDP.Asynchronous() do m
                     optimizer = d.parallel_optimizer()
@@ -264,6 +264,7 @@ function optimize_policy!(
         end
 
         if d.rundata.steady_state && !solveoptions.reset_starting_levels
+            println("in first location")
             solveresults = SDDP.train(
                 sddpm,
                 iteration_limit = solveoptions.iterations,
@@ -277,6 +278,7 @@ function optimize_policy!(
                 forward_pass = SDDP.DefaultForwardPass(; include_last_node = false),
             )
         else
+            println("in second location")
             solveresults = SDDP.train(
                 sddpm,
                 iteration_limit = solveoptions.iterations,

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -34,12 +34,13 @@ recommended to be set to false.
 function optimize_policy!(
     JADEmodel::JADEModel,
     solveoptions::JADESolveOptions;
-    async::Bool = false,
+    multithreaded::Bool = false,
     print_level::Int = 1,
 )
     d = JADEmodel.d
     sddpm = JADEmodel.sddpm
     previous_rundata = nothing
+    parallel_scheme = multithreaded ? SDDP.Threaded() : SDDP.Serial()
 
     check_settings_compatibility(rundata = d.rundata, solveoptions = solveoptions)
 
@@ -245,22 +246,6 @@ function optimize_policy!(
                 push!(sample_path, ((t - 1) % d.rundata.number_of_wks + 1, s_inflows))
             end
             push!(sample_paths, sample_path)
-        end
-
-        parallel_scheme = nothing
-        if async
-            if !hasproperty(d, :parallel_scheme)
-                parallel_scheme = SDDP.Threaded()
-            else
-                parallel_scheme = SDDP.Asynchronous() do m
-                    optimizer = d.parallel_optimizer()
-                    for node in values(m.nodes)
-                        set_optimizer(node.subproblem, optimizer)
-                    end
-                end
-            end
-        else
-            parallel_scheme = SDDP.Serial()
         end
 
         if d.rundata.steady_state && !solveoptions.reset_starting_levels

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -264,7 +264,6 @@ function optimize_policy!(
         end
 
         if d.rundata.steady_state && !solveoptions.reset_starting_levels
-            println("in first location")
             solveresults = SDDP.train(
                 sddpm,
                 iteration_limit = solveoptions.iterations,
@@ -278,7 +277,6 @@ function optimize_policy!(
                 forward_pass = SDDP.DefaultForwardPass(; include_last_node = false),
             )
         else
-            println("in second location")
             solveresults = SDDP.train(
                 sddpm,
                 iteration_limit = solveoptions.iterations,


### PR DESCRIPTION
Adds the kwarg `async` to simulate to allow this to happen.

The `if async` block on line 251-264 in `solve.jl` can probably be further reworked - I believe that the `JADEData` struct `d` no longer has the field parallel_optimizer so could be removed for a ternary `parallel_scheme = async ? SDDP.Threaded() : SDDP.Serial()`.