### PR TITLE
Update solve.jl - checking for upper bound of bellman function uses t…

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -97,7 +97,7 @@ function optimize_policy!(
         )
 
         check_rundata(d.rundata, previous_rundata, :eoh)
-        bf = sddpm[final_week].bellman_function
+        bf = sddpm[d.rundata.number_of_wks].bellman_function
         if JuMP.has_upper_bound(bf.global_theta.theta)
             JuMP.delete_upper_bound(bf.global_theta.theta)
         end


### PR DESCRIPTION
…he wrong bf

The replacement of the `JADE.read_finalcuts_from_file` function with the SDDP version takes the part:
```julia
bf = sddpm[final_week].bellman_function
if JuMP.has_upper_bound(bf.global_theta.theta)
    JuMP.delete_upper_bound(bf.global_theta.theta)
end
```
out of the function. However, within the original version the bellman function it was referencing is related to `d.rundata.number_of_wks` not `final_week`. See commit 1cb6ef7e8bcb3d64fb1d670bdab20b7749841464